### PR TITLE
Gemdir fix

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -8,6 +8,7 @@
 === Bugfixes
 * rvm-open-gem should now work with the standard ido distribution
 * the exec-path is now set properly
+* gem-home and gem-path are now set using `rvm info` instead of building the paths manually
 
 == 1.1 (16.05.2010)
 


### PR DESCRIPTION
I think this should fix the gemdir with global gemset stuff I messaged you about. It uses `rvm info`, passing it a `ruby@gemset` (instead of just a `ruby`), and using the resulting info to set the gemdir and gemhome. 
