### PR TITLE
Chomp gemset

### DIFF
--- a/History.txt
+++ b/History.txt
@@ -23,3 +23,6 @@
 
 === Bugfixes
 * Fixed setting of gemset path and ruby path
+
+=== Bugfixes
+* Fixed leading blanks in gemset name (global) using chomp

--- a/chomp.el
+++ b/chomp.el
@@ -1,0 +1,6 @@
+;; Put with other utils
+;; From http://www.emacswiki.org/emacs/ElispCookbook
+(defun chomp (str)
+  "Chomp leading and tailing whitespace from STR."
+  (let ((s (if (symbolp str) (symbol-name str) str)))
+    (replace-regexp-in-string "\\(^[[:space:]\n]*\\|[[:space:]\n]*$\\)" "" s)))

--- a/rvm.el
+++ b/rvm.el
@@ -1,6 +1,6 @@
 ;;; rvm.el --- Emacs integration for rvm
 
-;; Copyright (C) 2010 Yves Senn
+;; Copyright (C) 2010-2011 Yves Senn
 
 ;; Author: Yves Senn <yves.senn@gmx.ch>
 ;; URL: http://www.emacswiki.org/emacs/RvmEl
@@ -194,7 +194,7 @@ If no .rvmrc file is found, the default ruby is used insted."
           (let ((gemset (nth i gemset-lines)))
             (when (and (> (length gemset) 0)
                        (not (string-match rvm--gemset-list-filter-regexp gemset)))
-              (add-to-list 'parsed-gemsets gemset t))))
+                (add-to-list 'parsed-gemsets (chomp gemset) t))))
     parsed-gemsets))
 
 (defun rvm/info (&optional ruby-version)


### PR DESCRIPTION
# What the problem was:

I was getting errors running rvm-use, but not rvm-use-default
## Cause:

The name for the global gemset had leading spaces
## Example:

(split-string (rvm--call-process  "jruby-1.5.3" "gemset" "list") "\n")
### returns:

("" "gemsets for jruby-1.5.3 (found in /home/rickcharon/.rvm/gems/jruby-1.5.3)" "(space)(space)(space)    global" "" "")

(note spaces in "           global") - for some reason they dissapear in markdown
## Possible fix:

I added a chomp function

```
;; From http://www.emacswiki.org/emacs/ElispCookbook
(defun chomp (str)
"Chomp leading and tailing whitespace from STR."
  (let ((s (if (symbolp str) (symbol-name str) str)))
    (replace-regexp-in-string "\\(^[[:space:]\n]*\\|[[:space:]\n]*$\\)" "" s)))
```

added a call to chomp in rvm/gemset-list.
