### PR TITLE
Enable rvmrc line ending after gemset.

### DIFF
--- a/rvm.el
+++ b/rvm.el
@@ -99,7 +99,7 @@ This path gets added to the PATH variable and the exec-path list.")
                                         rvm--gemset-separator
                                         "\n]+\\)\\(?:"
                                         rvm--gemset-separator
-                                        "\\([^\"]+\\)\\)?\\(?:\"\\|\\)")
+                                        "\\([^\"\s]+\\)\\)?\\(?:\"\\|\\)")
   "regular expression to parse the .rvmrc files inside project directories.
 the first group matches the ruby-version and the second group is the gemset.
 when no gemset is set, the second group is nil")


### PR DESCRIPTION
Example rvmrc that was failing for me and was fixed by this regexp change:

rvm_archflags="-arch x86_64"
rvm 1.8.7@nginx --create
export rvm_trust_rvmrcs_flag=1

Problem was with the "--create" parameter, that was parsed as part of gemset name
