### PR TITLE
Load Elisp files from Ruby's source

### DIFF
--- a/rvm.el
+++ b/rvm.el
@@ -283,7 +283,7 @@ If no .rvmrc file is found, the default ruby is used insted."
 
 (defun rvm--set-ruby-src (gemhome)
   (progn
-    (setq 'rvm--current-ruby-src-path
+    (setq rvm--current-ruby-src-path
           (concat (file-name-as-directory (replace-regexp-in-string "gems"
                                                                     "src"
                                                                     gemhome))


### PR DESCRIPTION
When switching Rubies add the Elisp files that ship with the Ruby source to the load-path. These are located in ~/.rvm/src/_ruby_/misc
