### PR TITLE
fix rvm--list-ruby-regexp, ando add rvm-gemset-list-regexp.

### DIFF
--- a/rvm.el
+++ b/rvm.el
@@ -89,11 +89,14 @@ This path gets added to the PATH variable and the exec-path list.")
 (defvar rvm--info-option-regexp "\s+\\(.+\\):\s+\"\\(.+\\)\""
   "regular expression to parse the options from rvm info")
 
-(defvar rvm--list-ruby-regexp "\s*\\(=>\\)?\s*\\(.+?\\)\s*\\[\\(.+\\)\\]\s*$"
+(defvar rvm--list-ruby-regexp "\s*\\(=?[>\*]\\)?\s*\\(.+?\\)\s*\\[\\(.+\\)\\]\s*$"
   "regular expression to parse the ruby version from the 'rvm list' output")
 
 (defvar rvm--gemset-list-filter-regexp "^\\(gemsets for\\|Gemset '\\)"
   "regular expression to filter the output of rvm gemset list")
+
+(defvar rvm--gemset-list-regexp "\s*\\(=>\\)?\s*\\(.+?\\)\s*$"
+  "regular expression to parse the gemset from the 'rvm gemset list' output")
 
 (defvar rvm--rvmrc-parse-regexp (concat "\\(?:^rvm\s+\\(?:use\s+\\|\\)\\|environment_id=\"\\)\s*"
                                         "\\(?:--.+\s\\)*" ;; Flags
@@ -215,8 +218,9 @@ If no .rvmrc file is found, the default ruby is used insted."
     (loop for i from 0 to (length gemset-lines) do
           (let ((gemset (nth i gemset-lines)))
             (when (and (> (length gemset) 0)
-                       (not (string-match rvm--gemset-list-filter-regexp gemset)))
-              (add-to-list 'parsed-gemsets (chomp gemset) t))))
+                       (not (string-match rvm--gemset-list-filter-regexp gemset))
+                       (string-match rvm--gemset-list-regexp gemset))
+              (add-to-list 'parsed-gemsets (match-string 2 gemset) t))))
     parsed-gemsets))
 
 (defun rvm/info (&optional ruby-version)

--- a/tests/rvm_stubs/ruby-1.9.2-head_rvm_gemset_list
+++ b/tests/rvm_stubs/ruby-1.9.2-head_rvm_gemset_list
@@ -2,7 +2,7 @@
 gemsets for ruby-1.9.2-head (found in /Users/senny/.rvm/gems/ruby-1.9.2-head)
 
 experimental
-  global
-rails3
-rails3-beta4
-rails3beta
+=> global
+   rails3
+   rails3-beta4
+   rails3beta

--- a/tests/rvm_stubs/rvm_list
+++ b/tests/rvm_stubs/rvm_list
@@ -6,4 +6,3 @@ rvm rubies
 => ruby-1.9.2-head [ x86_64 ]
    ruby-1.9.2-preview1 [ i386 ]
    ruby-head [ x86_64 ]
-


### PR DESCRIPTION
completion for 'M-x rvm-use' is broken, because regexp for list and gem list are not compatible with current rvm.
