### PR TITLE
Although rvm-configuration-file-name was configured, rvm--rvmrc-locate was not using it.

### DIFF
--- a/rvm.el
+++ b/rvm.el
@@ -294,7 +294,7 @@ If no .rvmrc file is found, the default ruby is used insted."
    ((equal (expand-file-name path) (expand-file-name "~")) nil)
    ((equal (expand-file-name path) "/") nil)
    ((member rvm-configuration-file-name (directory-files path))
-    (concat (expand-file-name path) "/.rvmrc"))
+    (concat (expand-file-name path) "/" rvm-configuration-file-name))
    (t (rvm--rvmrc-locate (concat (file-name-as-directory path) "..")))))
 
 (defun rvm--rvmrc-read-version (path-to-rvmrc)


### PR DESCRIPTION
My .rvmrc is a shell script, pretty complex (depending on $HOSTNAME), so it cannot be parsed by rvm.el.

I created .rvmrc.el with just one line, and customized rvm-configuration-file-name to ".rvmrc.el".

I expected rvm--rvmrc-locate to find this file, but it was always using ".rvmrc".

This should fix it.

Sorry about not providing any tests, but there are no tests for this behaviour and I am not so fluent testing emacs modules to be able to test it.
