### PR TITLE
Setup for running the tests on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: ruby
+rvm: 1.9.3
+
+# This boldly assumes that "emacs" is installed on the Travis build slave.
+script: emacs --script tests/rvm-tests

--- a/tests/.rvmrc
+++ b/tests/.rvmrc
@@ -1,1 +1,1 @@
-rvm ruby-1.9.2-head@rails3
+rvm --create ruby-1.9.2-head@rails3

--- a/tests/rvm-tests
+++ b/tests/rvm-tests
@@ -13,4 +13,4 @@
 (dolist (test-file (or argv (directory-files rvm-test-path t "-tests.el$")))
   (load test-file nil t))
 
-(ert-run-tests-batch t)
+(ert-run-tests-batch-and-exit t)


### PR DESCRIPTION
I just figuring out how to use rvm.el, inspired by https://github.com/technomancy/zossima and http://devblog.avdi.org/2011/10/11/rvm-el-and-inf-ruby-emacs-reboot-14/

I am so happy to see you have tests! This commit adds in setups so that tests can be run automatically by https://travis-ci.org/.

This is the rest of my git commit message:
Change the test run itself from:

```
(ert-run-tests-batch t)
```

to:

```
(ert-run-tests-batch-and-exit t)
```

so that failed tests give a failure status out of running Emacs.
This allows Travis to notice failures.

Add "--create" into .rvmrc, mostly for convenience. I'm not at all
sure Travis cares.
