### PR TITLE
strip comments from .rvmrc file before parsing version

### DIFF
--- a/rvm.el
+++ b/rvm.el
@@ -302,9 +302,10 @@ If no .rvmrc file is found, the default ruby is used insted."
     (rvm--rvmrc-parse-version (buffer-string))))
 
 (defun rvm--rvmrc-parse-version (rvmrc-line)
-  (when (string-match rvm--rvmrc-parse-regexp rvmrc-line)
-    (list (rvm--string-trim (match-string 1 rvmrc-line))
-          (rvm--string-trim (or (match-string 2 rvmrc-line) rvm--gemset-default)))))
+  (let ((rvmrc-without-comments (replace-regexp-in-string "#.*$" "" rvmrc-line)))
+    (when (string-match rvm--rvmrc-parse-regexp rvmrc-without-comments)
+      (list (rvm--string-trim (match-string 1 rvmrc-without-comments))
+            (rvm--string-trim (or (match-string 2 rvmrc-without-comments) rvm--gemset-default))))))
 
 (defun rvm--gem-binary-path-from-gem-path (gempath)
   (let ((gem-paths (split-string gempath ":")))

--- a/tests/rvm-unit-tests.el
+++ b/tests/rvm-unit-tests.el
@@ -123,3 +123,10 @@ fi
 
 # Something")
                  '("1.9.2" "project"))))
+
+(ert-deftest rvm-read-version-removes-comments ()
+  (should (equal (rvm--rvmrc-parse-version "# comment 1
+rvm --create ruby-1.9.2-head@rails3 # comment 2
+# comment 3
+")
+                 '("ruby-1.9.2-head" "rails3"))))


### PR DESCRIPTION
reworked patch from #31
