### PR TITLE
Add gnu as source in Cask file.

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,3 +1,4 @@
+(source gnu)
 (source melpa)
 
 (package-file "rvm.el")


### PR DESCRIPTION
Emacs 23 is currently broken in Ert runner, so that should be fixed soon. If you want you can just comment out that line until fixed. Not even sure if you support Emacs 23 :)

This should fix 24.1 and 24.2.
