### PR TITLE
Support all Gemfile ruby-version forms

### DIFF
--- a/History.md
+++ b/History.md
@@ -25,6 +25,7 @@
 * the exec-path is now set properly
 * gem-home and gem-path are now set using `rvm info` instead of building the paths manually
 * bug-fix in rvm--rvmrc-parse-version which was incorrectly reading some rvmrc files
+* support both Gemfile syntaxes for ruby-version
 
 # 1.1 (16.05.2010)
 

--- a/rvm.el
+++ b/rvm.el
@@ -121,8 +121,11 @@ This path gets added to the PATH variable and the exec-path list.")
 (defvar rvm--gemset-list-regexp "\s*\\(=>\\)?\s*\\(.+?\\)\s*$"
   "regular expression to parse the gemset from the 'rvm gemset list' output")
 
-(defvar rvm--gemfile-parse-ruby-regexp "\\#ruby=\\(.+\\)"
-  "regular expression to parse the ruby version from the Gemfile")
+(defvar rvm--gemfile-parse-ruby-regexp-as-comment "\\#ruby=\\(.+\\)"
+  "regular expression to parse the ruby version from the Gemfile as comment")
+
+(defvar rvm--gemfile-parse-ruby-regexp-as-directive "ruby [\'\"]\\(.+\\)[\'\"]"
+  "regular expression to parse the ruby version from the Gemfile as directive")
 
 (defvar rvm--gemfile-parse-gemset-regexp "#ruby-gemset=\\(.+\\)"
   "regular expression to parse the ruby gemset from the Gemfile")
@@ -377,10 +380,11 @@ function."
             (rvm--string-trim (or (match-string 2 rvmrc-without-comments) rvm--gemset-default))))))
 
 (defun rvm--gemfile-parse-version (gemfile-line)
-  (let ((ruby-version (when (string-match rvm--gemfile-parse-ruby-regexp gemfile-line)
-                       (match-string 1 gemfile-line)))
-    (ruby-gemset (when (string-match rvm--gemfile-parse-gemset-regexp gemfile-line)
-                   (match-string 1 gemfile-line))))
+  (let ((ruby-version (when (or (string-match rvm--gemfile-parse-ruby-regexp-as-comment gemfile-line)
+				(string-match rvm--gemfile-parse-ruby-regexp-as-directive gemfile-line))
+			(match-string 1 gemfile-line)))
+	(ruby-gemset (when (string-match rvm--gemfile-parse-gemset-regexp gemfile-line)
+		       (match-string 1 gemfile-line))))
     (if ruby-version
         (list ruby-version (or ruby-gemset rvm--gemset-default))
       nil)))

--- a/test/rvm-unit-test.el
+++ b/test/rvm-unit-test.el
@@ -60,9 +60,21 @@
   (should (equal (rvm--rvmrc-parse-version "environment_id=\"ruby-1.9.2-p180-patched@something\"")
                  '("ruby-1.9.2-p180-patched" "something"))))
 
-(ert-deftest rvm-unit-test-gemfile-parse-version ()
+(ert-deftest rvm-unit-test-gemfile-parse-version-as-comment ()
   (should (equal (rvm--gemfile-parse-version "#ruby=1.9.3\n#ruby-gemset=foo")
                  '("1.9.3" "foo"))))
+
+(ert-deftest rvm-unit-test-gemfile-parse-version-as-directive-with-single-quotes ()
+  (should (equal (rvm--gemfile-parse-version "ruby '1.9.3'\n#ruby-gemset=foo")
+                 '("1.9.3" "foo"))))
+
+(ert-deftest rvm-unit-test-gemfile-parse-version-as-directive-with-double-quotes ()
+  (should (equal (rvm--gemfile-parse-version "ruby \"1.9.3\"\n#ruby-gemset=foo")
+                 '("1.9.3" "foo"))))
+
+(ert-deftest rvm-unit-test-gemfile-parse-version-reject-directive-with-equals ()
+  (should-not (equal (rvm--gemfile-parse-version "ruby=\"1.9.3\"\n#ruby-gemset=foo")
+		     '("1.9.3" "foo"))))
 
 (ert-deftest rvm-unit-test-gemfile-parse-version-without-gemset ()
   (should (equal (rvm--gemfile-parse-version "#ruby=1.9.3\n")


### PR DESCRIPTION
This pull request fixes issue #43:

When ruby-version is taken from Gemfile, [three syntaxes](http://rvm.io/workflow/projects) are supported:

```
#ruby=2.1.0
ruby "2.1.0"
ruby '2.1.0'
```

Currently, rvm.el only recognizes the comment form. But the directive form(s) mean something to Bundler, and should also be allowed.
