### PR TITLE
Near beats far: Conform to RVM's behavior when rc files are found several depths up-tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /rvm.elc
 /.cask
+TAGS

--- a/test/rvm-integration-test.el
+++ b/test/rvm-integration-test.el
@@ -181,3 +181,15 @@
        (f-join rvm-test/test-path "project")
        (lambda () (error "BooM"))))
      (should-be-default-rvm-environment))))
+
+(ert-deftest rvm-test-activate-corresponding-ruby-with-gemfile-closer-than-rvmrc ()
+  (rvm-test-environment (lambda ()
+                          (cd (concat (file-name-directory
+				       (symbol-file 'get-rvm-stub))
+				      "/" "rvmrc" "/" "elsewhere"))
+                          (rvm-activate-corresponding-ruby)
+                          (should-be-rvm-environment
+                           '("/Users/senny/.rvm/rubies/ruby-1.8.7-p249/bin/")
+                           "/Users/senny/.rvm/gems/ruby-1.8.7-p249@experimental"
+                           "/Users/senny/.rvm/gems/ruby-1.8.7-p249@experimental:/Users/senny/.rvm/gems/ruby-1.8.7-p249@global")
+                          )))

--- a/test/rvmrc/elsewhere/Gemfile
+++ b/test/rvmrc/elsewhere/Gemfile
@@ -1,0 +1,2 @@
+#ruby=1.8.7-p249
+#ruby-gemset=experimental


### PR DESCRIPTION
(See #45)

RVM does
- For each containing directory above the start point
  - if there's  a `.rvmrc`, use it; else use `.ruby-version`; else use `Gemfile`
  - else, recurse up-tree

In this way, the precedence among files at a given depth is ".rvmrc > .ruby-version > Gemfile", but nearer files of any name win over remoter files of any name.

`rvm.el` currently uses different logic:
- Search all the way up-tree for `.rvmrc`; if found, use it
- Else search all over again, for `.ruby-version`; if found, use it
- Else search one more time for `Gemfile`; use or give up

Where there are several rc files up-tree, of different depths and different types (file names), `rvm` and `rvm.el` may choose different settings.

This fixes that.
