### PR TITLE
Prefix the chomp function

### DIFF
--- a/History.md
+++ b/History.md
@@ -6,6 +6,8 @@
 
 ## Bugfixes
 
+* Fix naming conflict with electric-pair-mode
+
 # 1.2.0 (01.02.2012)
 
 [Compare v1.2.0..master](https://github.com/senny/rvm.el/compare/1.1...1.2.0)

--- a/rvm.el
+++ b/rvm.el
@@ -145,7 +145,7 @@ when no gemset is set, the second group is nil")
 
 ;; Put with other utils
 ;; From http://www.emacswiki.org/emacs/ElispCookbook
-(defun chomp (str)
+(defun rvm--chomp (str)
   "Chomp leading and tailing whitespace from STR."
   (let ((s (if (symbolp str) (symbol-name str) str)))
     (replace-regexp-in-string "\\(^[[:space:]\n]*\\|[[:space:]\n]*$\\)" "" s)))
@@ -188,9 +188,9 @@ If no .rvmrc file is found, the default ruby is used insted."
   (let ((config-file-path (rvm--locate-file rvm-configuration-ruby-version-file-name path))
         (gemset-file-path (rvm--locate-file rvm-configuration-ruby-gemset-file-name path)))
     (if config-file-path
-        (list (chomp (rvm--get-string-from-file config-file-path))
+        (list (rvm--chomp (rvm--get-string-from-file config-file-path))
               (if gemset-file-path
-                  (chomp (rvm--get-string-from-file gemset-file-path))
+                  (rvm--chomp (rvm--get-string-from-file gemset-file-path))
                 rvm--gemset-default))
       nil)))
 


### PR DESCRIPTION
The chomp function causes a conflict with electric-pair-mode, which
checks to see if the value of electric-pair-skip-whitespace is a
function, and if so tries to call that function. It calls this function
without any arguments, which causes a wrong number of arguments error.

I've also sent a bug report to the Emacs bug tracker, since I don't think it should call the `chomp` function in the case it exists, but it also seems prudent to prefix this function's name so it won't interfere with other places where this may be defined.