### PR TITLE
Cask doesn't support Emacs below version 24 anymore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,13 @@
 language: emacs-lisp
 before_install:
-  - curl -fsSkL https://gist.github.com/senny/8003271/raw | sh
-  - export PATH="/home/travis/.cask/bin:$PATH"
-  - export PATH="/home/travis/.evm/bin:$PATH"
-  - evm install $EVM_EMACS --use
+  - curl -fsSkL https://gist.github.com/senny/8003271/raw > travis.sh && source ./travis.sh
+  - evm install $EVM_EMACS --use --skip
   - cask
 env:
-  - EVM_EMACS=emacs-23.4-bin
   - EVM_EMACS=emacs-24.1-bin
   - EVM_EMACS=emacs-24.2-bin
   - EVM_EMACS=emacs-24.3-bin
+  - EVM_EMACS=emacs-24.4-bin
 script:
   - emacs --version
   - make test


### PR DESCRIPTION
Hi @senny 

It looks like there is no support for Emacs 23 anymore by Cask https://github.com/cask/cask/blob/master/bin/cask#L54