### PR TITLE
Strip wrapping parens from around default gemset returned by rvm info

### DIFF
--- a/rvm.el
+++ b/rvm.el
@@ -296,7 +296,9 @@ function."
                      ruby-current-version
                      (not filtered-gemset)
                      (string-match rvm--gemset-list-regexp gemset))
-                (add-to-list 'parsed-gemsets (match-string 2 gemset) t))))
+                ;; replace-regexp is to handle default gemset which is returned with
+                ;; wrapping parens but is referred to without them in rvm use command
+                (add-to-list 'parsed-gemsets (replace-regexp-in-string "^(\\|)$" "" (match-string 2 gemset)) t))))
     parsed-gemsets))
 
 (defun rvm/info (&optional ruby-version)

--- a/test/rvm-integration-test.el
+++ b/test/rvm-integration-test.el
@@ -107,7 +107,7 @@
 
 (ert-deftest rvm-test-rvm/gemset-list ()
   (let* ((result (rvm/gemset-list "ruby-1.9.2-head")))
-    (should (equal result '("experimental" "global" "rails3" "rails3-beta4" "rails3beta")))))
+    (should (equal result '("default" "experimental" "global" "rails3" "rails3-beta4" "rails3beta")))))
 
 (ert-deftest rvm-test-rvm/gemset-list-other-ruby ()
   (let* ((result (rvm/gemset-list "ruby-1.9.3-head")))

--- a/test/rvm_stubs/rvm_gemset_list
+++ b/test/rvm_stubs/rvm_gemset_list
@@ -1,5 +1,6 @@
 
 gemsets for ruby-1.9.2-head (found in /Users/senny/.rvm/gems/ruby-1.9.2-head)
+   (default)
    experimental
 => global
    rails3
@@ -13,4 +14,3 @@ gemsets for ruby-1.9.3-head (found in /Users/senny/.rvm/gems/ruby-1.9.3-head)
 
 gemsets for ruby-2.0.0-p195 (found in /Users/senny/.rvm/gems/ruby-2.0.0-195)
    awesome
-


### PR DESCRIPTION
fixes https://github.com/senny/rvm.el/issues/51