### PR TITLE
Fix emacs native compilation warning

### DIFF
--- a/rvm.el
+++ b/rvm.el
@@ -102,24 +102,24 @@
   "character that separates the ruby version from the gemset.")
 
 (defvar rvm--current-ruby-binary-path nil
-  "reflects the path to the current 'ruby' executable.
+  "reflects the path to the current `ruby' executable.
 This path gets added to the PATH variable and the exec-path list.")
 
 (defvar rvm--current-gem-binary-path nil
-  "reflects the path to the current 'rubygems' executables.
+  "reflects the path to the current `rubygems' executables.
 This path gets added to the PATH variable and the exec-path list.")
 
 (defvar rvm--info-option-regexp "\s+\\(.+?\\):\s+\"\\(.+?\\)\""
   "regular expression to parse the options from rvm info")
 
 (defvar rvm--list-ruby-regexp "\s*\\(=?[>\*]\\)?\s*\\(.+?\\)\s*\\[\\(.+\\)\\]\s*$"
-  "regular expression to parse the ruby version from the 'rvm list' output")
+  "regular expression to parse the ruby version from the `rvm list' output")
 
 (defvar rvm--gemset-list-filter-regexp "^\\(gemsets for\\|Gemset '\\)"
   "regular expression to filter the output of rvm gemset list")
 
 (defvar rvm--gemset-list-regexp "\s*\\(=>\\)?\s*\\(.+?\\)\s*$"
-  "regular expression to parse the gemset from the 'rvm gemset list' output")
+  "regular expression to parse the gemset from the `rvm gemset list' output")
 
 (defvar rvm--gemfile-parse-ruby-regexp-as-comment "\\#ruby=\\(.+\\)"
   "regular expression to parse the ruby version from the Gemfile as comment")
@@ -376,7 +376,8 @@ function."
   (rvm--change-path 'rvm--current-ruby-binary-path (list ruby-binary)))
 
 (defun rvm--locate-file (file-name &optional path)
-  "searches the directory tree for an given file. Returns nil if the file was not found."
+  "searches the directory tree for an given file. Returns nil if the
+file was not found."
   (let ((directory (locate-dominating-file (or path (expand-file-name (or buffer-file-name ""))) file-name)))
     (when directory (expand-file-name file-name directory))))
 


### PR DESCRIPTION
To reproduce, have emacs built with native compilation and notice the compilation logs. You can then open the offending file and run `M-x emacs-lisp-native-compile-and-load` before and after the changes to see the warning is removed.

```
 ■  Warning (comp): rvm.el:106:2: Warning: defvar
`rvm--current-ruby-binary-path' docstring has wrong usage of unescaped
single quotes (use \= or different quoting)

 ■  Warning (comp): rvm.el:110:2: Warning: defvar
`rvm--current-gem-binary-path' docstring has wrong usage of unescaped
single quotes (use \= or different quoting)

 ■  Warning (comp): rvm.el:117:2: Warning: defvar
`rvm--list-ruby-regexp' docstring has wrong usage of unescaped single
quotes (use \= or different quoting)

 ■  Warning (comp): rvm.el:123:2: Warning: defvar
`rvm--gemset-list-regexp' docstring has wrong usage of unescaped single
quotes (use \= or different quoting)

 ■  Warning (comp): rvm.el:380:2: Warning: docstring wider than 80
characters
```